### PR TITLE
Removed USER_ID environment variable

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -3,9 +3,6 @@
 #
 # Environment variables:
 # - APP_ROOT: The root application directory. Set in base image.
-# - USER_ID: The USER ID used for the non-privileged "application" account. Set in base image.
-# - JAVA_HOME: The Java installation directory. Set in base image.
-# - JAVA_OPTIONS: Java command line options used to configure the JVM. Set in base image.
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 LABEL maintainer="Linux for Health"
@@ -21,12 +18,11 @@ RUN microdnf update -y && \
     microdnf clean all
 
 ENV APP_ROOT=/opt/lfh
-ENV USER_ID=1001
 
 RUN mkdir -p ${APP_ROOT}
-RUN useradd -u ${USER_ID} -r -g 0 \
+RUN useradd -u 1001 -r -g 0 \
             -s /sbin/nologin \
-            -c "Default LFH Application User" \
+            -c "Linux for Health Application User" \
             lfh
 
-RUN chown -R ${USER_ID}:0 ${APP_ROOT}
+RUN chown -R lfh:0 ${APP_ROOT}

--- a/kafka-standalone/Dockerfile
+++ b/kafka-standalone/Dockerfile
@@ -9,7 +9,6 @@
 #
 # Environment variables:
 # - APP_ROOT: The root application directory. Set in base image.
-# - USER_ID: The USER ID used for the non-privileged "application" account. Set in base image.
 # - JAVA_HOME: The Java installation directory. Set in base image.
 # - KAFKA_ZOOKEEPER_CONNECT: Specifies the Zookeeper host and port (maps to zookeeper.connect property)
 # - KAFKA_LISTENERS: Broker listening addresses (maps to listeners property)
@@ -40,7 +39,6 @@ LABEL summary="Kafka Standalone Deployment for Linux For Health"
 LABEL description="Provides a standalone deployment for non-production use"
 
 ENV APP_ROOT=${APP_ROOT}
-ENV USER_ID=${USER_ID}
 ENV JAVA_HOME=${JAVA_HOME}
 
 ENV KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181

--- a/openjdk/Dockerfile
+++ b/openjdk/Dockerfile
@@ -6,7 +6,6 @@
 #
 # Environment variables:
 # - APP_ROOT: The root application directory. Set in base image.
-# - USER_ID: The USER ID used for the non-privileged "application" account. Set in base image.
 # - JAVA_HOME: The Java installation directory
 # - JAVA_OPTIONS: Java command line options used to configure the JVM. Defaults to include the UseContainerSupport options
 
@@ -20,7 +19,6 @@ LABEL summary="Linux For Health JDK Image"
 LABEL description="Provides support for Linux for HealthJDK based applications"
 
 ENV APP_ROOT=$APP_ROOT
-ENV USER_ID=$USER_ID
 ENV JAVA_HOME=/usr/lib/jvm/jre
 ENV JAVA_OPTIONS="-XX:+UseContainerSupport"
 

--- a/zookeeper-standalone/Dockerfile
+++ b/zookeeper-standalone/Dockerfile
@@ -7,7 +7,6 @@
 #
 # Environment variables:
 # - APP_ROOT: The root application directory. Set in base image.
-# - USER_ID: The USER ID used for the non-privileged "application" account. Set in base image.
 # - JAVA_HOME: The Java installation directory. Set in base image.
 
 FROM docker.io/linuxforhealth/base:1.0.0  AS builder
@@ -35,7 +34,6 @@ LABEL summary="ZooKeeper Standalone Deployment for Linux For Health"
 LABEL description="Provides a standalone ZooKeeper deployment for non-production use"
 
 ENV APP_ROOT=${APP_ROOT}
-ENV USER_ID=${USER_ID}
 ENV JAVA_HOME=${JAVA_HOME}
 
 USER lfh


### PR DESCRIPTION
This PR simply removes the USER_ID environment variable from the Linux For Health base image. It was nice to have as "documentation" but isn't something we should allow users to set within an image. We are standardizing on:

- lfh (user name)
- 1001 (user id)