### PR TITLE
Address ENV Usage Issues

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -2,7 +2,7 @@
 # Builds a base image for use by Linux for Health applications and services
 #
 # Environment variables:
-# - APP_ROOT: The root application directory. Set in base image.
+# - APP_ROOT: The root application directory.
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 LABEL maintainer="Linux for Health"

--- a/golang/Dockerfile
+++ b/golang/Dockerfile
@@ -3,7 +3,6 @@
 #
 # Environment variables:
 # - APP_ROOT: The root application directory. Set in base image.
-# - USER_ID: The USER ID used for the non-privileged "application" account. Set in base image.
 # - GOPATH: Sets the golang "workspace" for the image to the $APP_ROOT
 
 FROM docker.io/linuxforhealth/base:1.0.0 AS builder
@@ -15,7 +14,6 @@ LABEL com.linuxforhealth.license_terms="https://www.apache.org/licenses/LICENSE-
 LABEL summary="Linux For Health Golang Image"
 LABEL description="Provides support for Linux for Health Golang based applications"
 
-ENV APP_ROOT=$APP_ROOT
 ENV GOPATH=$APP_ROOT/gocode
 
 RUN mkdir -p ${GOPATH}/{bin,pkg,src} && \

--- a/kafka-standalone/Dockerfile
+++ b/kafka-standalone/Dockerfile
@@ -9,7 +9,12 @@
 #
 # Environment variables:
 # - APP_ROOT: The root application directory. Set in base image.
-# - GOPATH: Sets the golang "workspace" for the image to the $APP_ROOT
+# - JAVA_HOME: The Java installation directory. Set in base image.
+# - KAFKA_ZOOKEEPER_CONNECT: Specifies the Zookeeper host and port (maps to zookeeper.connect property)
+# - KAFKA_LISTENERS: Broker listening addresses (maps to listeners property)
+# - KAFKA_ADVERTISED_LISTENERS:  The Kafka listener metadata passed back to clients (maps to advertised.listeners)
+# - KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: Specifies the protocol used for each listener (maps to listener.security.protocol.map)
+# - KAFKA_INTER_BROKER_LISTENER_NAME:  The listener used for internal connections (inter.broker.listener.name)
 
 FROM docker.io/linuxforhealth/base:1.0.0  AS builder
 

--- a/kafka-standalone/Dockerfile
+++ b/kafka-standalone/Dockerfile
@@ -9,12 +9,7 @@
 #
 # Environment variables:
 # - APP_ROOT: The root application directory. Set in base image.
-# - JAVA_HOME: The Java installation directory. Set in base image.
-# - KAFKA_ZOOKEEPER_CONNECT: Specifies the Zookeeper host and port (maps to zookeeper.connect property)
-# - KAFKA_LISTENERS: Broker listening addresses (maps to listeners property)
-# - KAFKA_ADVERTISED_LISTENERS:  The Kafka listener metadata passed back to clients (maps to advertised.listeners)
-# - KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: Specifies the protocol used for each listener (maps to listener.security.protocol.map)
-# - KAFKA_INTER_BROKER_LISTENER_NAME:  The listener used for internal connections (inter.broker.listener.name)
+# - GOPATH: Sets the golang "workspace" for the image to the $APP_ROOT
 
 FROM docker.io/linuxforhealth/base:1.0.0  AS builder
 
@@ -38,9 +33,6 @@ LABEL com.linuxforhealth.license_terms="https://www.apache.org/licenses/LICENSE-
 LABEL summary="Kafka Standalone Deployment for Linux For Health"
 LABEL description="Provides a standalone deployment for non-production use"
 
-ENV APP_ROOT=${APP_ROOT}
-ENV JAVA_HOME=${JAVA_HOME}
-
 ENV KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
 ENV KAFKA_LISTENERS=PLAINTEXT://:9092
 ENV KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://localhost:9092
@@ -54,11 +46,8 @@ RUN chown lfh:root -R ${APP_ROOT}/kafka
 
 USER lfh
 
-# kafka broker 1
-EXPOSE 9092
-
-# kafka broker 2
-EXPOSE 9094
+# kafka brokers 1
+EXPOSE 9092 9094
 
 WORKDIR ${APP_ROOT}
 

--- a/nats-server/Dockerfile
+++ b/nats-server/Dockerfile
@@ -1,10 +1,19 @@
+# Linux for Health nats-server iamge.
+#
+# This image provides nats-server node for non-production use.
+#
+# Build arguments:
+# - NATS_SERVER_REPOSITORY_URL: The nats-server git repo URL
+# - NATS_SERVER_RELEASE: The nats-server git release tag
+#
+# Environment variables:
+# - APP_ROOT: The root application directory. Set in base image.
+# - GOPATH: Sets the golang "workspace" for the image to the $APP_ROOT. Set in base image
+
 FROM docker.io/linuxforhealth/golang:1.13 AS builder
 
 ARG NATS_SERVER_REPOSITORY_URL=https://github.com/nats-io/nats-server.git
 ARG NATS_SERVER_RELEASE_TAG=v2.1.7
-
-ENV APP_ROOT=${APP_ROOT}
-ENV GOPATH=${GOPATH}
 
 RUN mkdir -p /tmp/nats-server
 RUN mkdir -p ${GOPATH}/{bin,pkg,src}
@@ -24,11 +33,11 @@ FROM docker.io/linuxforhealth/base:1.0.0
 
 RUN mkdir -p ${APP_ROOT}/nats
 
-COPY --from=builder /tmp/nats-server* /opt/lfh/nats/
+COPY --from=builder /tmp/nats-server* ${APP_ROOT}/nats/
 RUN chown -R lfh:root ${APP_ROOT}
 
 USER lfh
-WORKDIR /opt/lfh/nats
+WORKDIR ${APP_ROOT}/nats
 
 # Expose client, management, cluster and gateway ports
 EXPOSE 4222 8222 6222 5222

--- a/openjdk/Dockerfile
+++ b/openjdk/Dockerfile
@@ -18,7 +18,6 @@ LABEL com.linuxforhealth.license_terms="https://www.apache.org/licenses/LICENSE-
 LABEL summary="Linux For Health JDK Image"
 LABEL description="Provides support for Linux for HealthJDK based applications"
 
-ENV APP_ROOT=$APP_ROOT
 ENV JAVA_HOME=/usr/lib/jvm/jre
 ENV JAVA_OPTIONS="-XX:+UseContainerSupport"
 

--- a/zookeeper-standalone/Dockerfile
+++ b/zookeeper-standalone/Dockerfile
@@ -33,13 +33,10 @@ LABEL com.linuxforhealth.license_terms="https://www.apache.org/licenses/LICENSE-
 LABEL summary="ZooKeeper Standalone Deployment for Linux For Health"
 LABEL description="Provides a standalone ZooKeeper deployment for non-production use"
 
-ENV APP_ROOT=${APP_ROOT}
-ENV JAVA_HOME=${JAVA_HOME}
-
 USER lfh
 
-RUN mkdir -p /opt/lfh/zookeeper
-COPY --from=builder tmp/zookeeper /opt/lfh/zookeeper
+RUN mkdir -p ${APP_ROOT}/zookeeper
+COPY --from=builder tmp/zookeeper ${APP_ROOT}/zookeeper
 
 # zookeeper
 EXPOSE 2181


### PR DESCRIPTION
This PR updates our use of the ENV command/directive to ensure that:

- We inherit ENV variables from "parent images" rather than make redundant assignments
- We use ENV variables rather than the literals they represent