### PR TITLE
Add PostgreSQL Dockerfile and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ Containers include:
 - [Golang](https://golang.org/) image to support Golang based applications
 - [Kafka](https://kafka.apache.org/) and [Zookeeper](https://zookeeper.apache.org/) for real time streaming and durable message persistence
 - [NATS](https://docs.nats.io/nats-streaming-concepts/intro) and a NATS subscriber for data streaming and events notifications
- 
+- [PostgreSQL](https://www.postgresql.org) for object-relational database use cases
+
 ## Multi-Architecture Build Process
 The build process leverages the multi-architecture features of build kit as provided through Docker's [buildx](https://docs.docker.com/buildx/working-with-buildx/) CLI.
 
@@ -16,6 +17,9 @@ Architectures supported include:
 - linux/amd64
 - linux/s390x
 - linux/arm64
+
+Architecture support exceptions:
+- The PostgreSQL image does not include support for linux/s390x or linux/arm64 at this time.
 
 Images are built using a command similar to:
 

--- a/postgres/Dockerfile
+++ b/postgres/Dockerfile
@@ -8,16 +8,20 @@
 
 FROM registry.access.redhat.com/ubi8/ubi-init:latest
 
+ARG POSTGRES_RELEASE_URL=https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm
+ARG POSTGRES_PACKAGE=postgresql12-server
 ENV PGDATA=/var/lib/pgsql/data/
 
-# Install PostgreSQL 12
-RUN dnf -y install https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm
-RUN dnf -y install postgresql12-server
+# Install PostgreSQL
+RUN dnf -y install ${POSTGRES_RELEASE_URL} && \
+  dnf -y install ${POSTGRES_PACKAGE} && \
+  dnf clean all
 
 # Run the following as postgres user
 USER postgres
 
 # Initialize data directory - e.g. /var/lib/pgsql/data/
+# RUN $(find /usr/pgsql*/bin -type d)/initdb ${PGDATA}
 RUN /usr/pgsql-12/bin/initdb ${PGDATA}
 
 # Allow remote connections to database

--- a/postgres/Dockerfile
+++ b/postgres/Dockerfile
@@ -21,8 +21,7 @@ RUN dnf -y install ${POSTGRES_RELEASE_URL} && \
 USER postgres
 
 # Initialize data directory - e.g. /var/lib/pgsql/data/
-# RUN $(find /usr/pgsql*/bin -type d)/initdb ${PGDATA}
-RUN /usr/pgsql-12/bin/initdb ${PGDATA}
+RUN $(find /usr/pgsql*/bin -type d)/initdb ${PGDATA}
 
 # Allow remote connections to database
 RUN echo "host  all  all 0.0.0.0/0  trust" >> /var/lib/pgsql/data/pg_hba.conf
@@ -34,4 +33,4 @@ RUN echo "listen_addresses='*'" >> /var/lib/pgsql/data/postgresql.conf
 EXPOSE 5432
 
 # Start PostgreSQL when the container starts
-CMD ["/usr/pgsql-12/bin/postgres", "-D", "${PGDATA}", "-c", "config_file=/var/lib/pgsql/data/postgresql.conf"]
+CMD ["sh", "-c", "$(find /usr/pgsql*/bin -type d)/postgres", "-c", "config_file=/var/lib/pgsql/data/postgresql.conf"]

--- a/postgres/Dockerfile
+++ b/postgres/Dockerfile
@@ -1,0 +1,33 @@
+# Linux for Health PostgreSQL image.
+#
+# This image serves PostgreSQL within a Red Hat UBI container.
+# Sample PostgreSQL Dockerfile: https://docs.docker.com/engine/examples/postgresql_service/
+#
+# Environment variables:
+# - PGDATA: The PostgreSQL data directory.
+
+FROM registry.access.redhat.com/ubi8/ubi-init:latest
+
+ENV PGDATA=/var/lib/pgsql/data/
+
+# Install PostgreSQL 12
+RUN dnf -y install https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm
+RUN dnf -y install postgresql12-server
+
+# Run the following as postgres user
+USER postgres
+
+# Initialize data directory - e.g. /var/lib/pgsql/data/
+RUN /usr/pgsql-12/bin/initdb ${PGDATA}
+
+# Allow remote connections to database
+RUN echo "host  all  all 0.0.0.0/0  trust" >> /var/lib/pgsql/data/pg_hba.conf
+
+# Listen on all IP addresses
+RUN echo "listen_addresses='*'" >> /var/lib/pgsql/data/postgresql.conf
+
+# Expose PostgreSQL port
+EXPOSE 5432
+
+# Start PostgreSQL when the container starts
+CMD ["/usr/pgsql-12/bin/postgres", "-D", "${PGDATA}", "-c", "config_file=/var/lib/pgsql/data/postgresql.conf"]

--- a/postgres/README.md
+++ b/postgres/README.md
@@ -8,7 +8,7 @@ The Linux for Health PostgreSQL server is intended for non-production use.
 docker buildx build \
               --pull \
               --push \
-              --platform linux/amd64,linux/s390x,linux/arm64 \
+              --platform linux/amd64 \
               -t docker.io/linuxforhealth/postgresql:<image version> .
 ```
 
@@ -20,3 +20,12 @@ lists the supported variables and the default value.
 | Variable Name | Default Value        |
 | ------------- | -------------------- |
 | PGDATA        | /var/lib/pgsql/data/ |
+
+## Container Build ARGs
+
+This container supports the following ARGs to customize PostgreSQL version installed therein.
+
+| Name | Description | Default Value        |
+| ---- | ---- | ---- |
+| POSTGRES_RELEASE_URL | Url of the PostgreSQL rpm to install. | https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm |
+| POSTGRES_PACKAGE | The PostgreSQL package name to install. | postgresql12-server |

--- a/postgres/README.md
+++ b/postgres/README.md
@@ -1,0 +1,22 @@
+# Linux for Health PostgreSQL Server
+
+The Linux for Health PostgreSQL server is intended for non-production use.
+
+## Build Command
+
+```
+docker buildx build \
+              --pull \
+              --push \
+              --platform linux/amd64,linux/s390x,linux/arm64 \
+              -t docker.io/linuxforhealth/postgresql:<image version> .
+```
+
+## Environment Variables
+
+PostgreSQL is configured at runtime using environment variables. The table below
+lists the supported variables and the default value.
+
+| Variable Name | Default Value        |
+| ------------- | -------------------- |
+| PGDATA        | /var/lib/pgsql/data/ |


### PR DESCRIPTION
This PR contributes to the resolution of LinuxForHealth/connect#59

Once built: 
```
$ docker run -p 5432:5432 IMAGE
```

To test connectivity once the image is started:
```
$ psql -U postgres -h localhost -p 5432
postgres=# create database test;

postgres=# \l
                             List of databases
   Name    |  Owner   | Encoding  | Collate | Ctype |   Access privileges   
-----------+----------+-----------+---------+-------+-----------------------
 postgres  | postgres | SQL_ASCII | C       | C     | 
 template0 | postgres | SQL_ASCII | C       | C     | =c/postgres          +
           |          |           |         |       | postgres=CTc/postgres
 template1 | postgres | SQL_ASCII | C       | C     | =c/postgres          +
           |          |           |         |       | postgres=CTc/postgres
 test      | postgres | SQL_ASCII | C       | C     | 
(4 rows)
```

**Note:** I've not been able to successfully build this PostgreSQL image for platforms `linux/s390x` and `linux/arm64`.
Getting 404s on the following rpms:
**_linux/s390x_** : https://download.postgresql.org/pub/repos/yum/common/redhat/rhel-8-s390x/repodata/repomd.xml
**_linux/arm64_** : https://download.postgresql.org/pub/repos/yum/common/redhat/rhel-8-aarch64/repodata/repomd.xml

Also, I was not able to get the PostgreSQL image built off the **ubi-minimal** base image. Had to use **ubi-init**.
Do we want different base images besides ubi-minimal or should I include some of the LABEL commands in this image?