### PR TITLE
Build postgresql image from lfh base image

### DIFF
--- a/postgres/Dockerfile
+++ b/postgres/Dockerfile
@@ -6,22 +6,22 @@
 # Environment variables:
 # - PGDATA: The PostgreSQL data directory.
 
-FROM registry.access.redhat.com/ubi8/ubi-init:latest
+FROM docker.io/linuxforhealth/base:1.0.0
 
 ARG POSTGRES_RELEASE_URL=https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm
 ARG POSTGRES_PACKAGE=postgresql12-server
 ENV PGDATA=/var/lib/pgsql/data/
 
 # Install PostgreSQL
-RUN dnf -y install ${POSTGRES_RELEASE_URL} && \
-  dnf -y install ${POSTGRES_PACKAGE} && \
-  dnf clean all
+RUN rpm -ivh ${POSTGRES_RELEASE_URL} && \
+  microdnf -y install ${POSTGRES_PACKAGE} && \
+  microdnf clean all
 
 # Run the following as postgres user
 USER postgres
 
 # Initialize data directory - e.g. /var/lib/pgsql/data/
-RUN $(find /usr/pgsql*/bin -type d)/initdb ${PGDATA}
+RUN $(ls -d /usr/pgsql*/bin)/initdb ${PGDATA}
 
 # Allow remote connections to database
 RUN echo "host  all  all 0.0.0.0/0  trust" >> /var/lib/pgsql/data/pg_hba.conf
@@ -33,4 +33,4 @@ RUN echo "listen_addresses='*'" >> /var/lib/pgsql/data/postgresql.conf
 EXPOSE 5432
 
 # Start PostgreSQL when the container starts
-CMD ["sh", "-c", "$(find /usr/pgsql*/bin -type d)/postgres", "-c", "config_file=/var/lib/pgsql/data/postgresql.conf"]
+CMD ["sh", "-c", "$(ls -d /usr/pgsql*/bin)/postgres", "-c", "config_file=/var/lib/pgsql/data/postgresql.conf"]


### PR DESCRIPTION
Figured out how to build the PostgreSQL image from the LFH base image rather than `ubi-init`.
The LFH base image is built from `ubi-minimal`, which has a smaller footprint than `ubi-init`.