### PR TITLE
Add POSTGRES_ENCODING Build Argument to PostgreSQL Image

### DIFF
--- a/postgres/Dockerfile
+++ b/postgres/Dockerfile
@@ -3,13 +3,26 @@
 # This image serves PostgreSQL within a Red Hat UBI container.
 # Sample PostgreSQL Dockerfile: https://docs.docker.com/engine/examples/postgresql_service/
 #
+# Build arguments:
+# - POSTGRES_RELEASE_URL: The URL to the PostgreSQL RPM repo. 
+#   Defaults to "latest" repo.
+#
+# - POSTGRES_PACKAGE: The PostgreSQL RPM package name.
+#   Defaults to postgresql12-server.
+#
+# - POSGRES_ENCODING: The character set used in the PostgreSQL databases.
+#   Defaults to UTF8.
+#
 # Environment variables:
-# - PGDATA: The PostgreSQL data directory.
+# - PGDATA: The PostgreSQL data directory. 
+# Defaults to /var/lib/pgsql/data/.
 
 FROM docker.io/linuxforhealth/base:1.0.0
 
 ARG POSTGRES_RELEASE_URL=https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm
 ARG POSTGRES_PACKAGE=postgresql12-server
+ARG POSTGRES_ENCODING=UTF8
+
 ENV PGDATA=/var/lib/pgsql/data/
 
 # Install PostgreSQL
@@ -21,7 +34,7 @@ RUN rpm -ivh ${POSTGRES_RELEASE_URL} && \
 USER postgres
 
 # Initialize data directory - e.g. /var/lib/pgsql/data/
-RUN $(ls -d /usr/pgsql*/bin)/initdb ${PGDATA}
+RUN $(ls -d /usr/pgsql*/bin)/initdb ${PGDATA} --encoding ${POSTGRES_ENCODING}
 
 # Allow remote connections to database
 RUN echo "host  all  all 0.0.0.0/0  trust" >> /var/lib/pgsql/data/pg_hba.conf

--- a/postgres/README.md
+++ b/postgres/README.md
@@ -29,3 +29,4 @@ This container supports the following ARGs to customize PostgreSQL version insta
 | ---- | ---- | ---- |
 | POSTGRES_RELEASE_URL | Url of the PostgreSQL rpm to install. | https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm |
 | POSTGRES_PACKAGE | The PostgreSQL package name to install. | postgresql12-server |
+| POSTGRES_ENCODING | The character set or encoding, used in database server | UTF8 |


### PR DESCRIPTION
This PR adds a POSTGRES_ENCODING build argument to the PostgreSQL Image, to allow users to specify a db character set at build time. If a character set is not specified, the argument defaults to UTF8.

Testing
```
Dixons-MBP compose$ source start-stack.sh dev
dev
===============================================
LFH Compose Startup
LFH compose profile is set to dev
starting LFH compose development profile
Parsing compose files for dev profile.
COMPOSE_FILE=docker-compose.yml:docker-compose.dev.yml
Creating compose_zookeeper_1   ... done
Creating compose_postgres_1    ... done
Creating compose_nats-server_1 ... done
Creating compose_orthanc_1     ... done
Creating compose_kafka_1       ... done
Creating compose_kafdrop_1     ... done
        Name                       Command               State                                        Ports
-------------------------------------------------------------------------------------------------------------------------------------------------
compose_kafdrop_1       ./kafdrop.sh                     Up      0.0.0.0:9000->9000/tcp
compose_kafka_1         sh -c ${APP_ROOT}/kafka/bi ...   Up      9092/tcp, 0.0.0.0:9094->9094/tcp
compose_nats-server_1   ./nats-server -c nats-serv ...   Up      0.0.0.0:4222->4222/tcp, 5222/tcp, 0.0.0.0:6222->6222/tcp, 0.0.0.0:8222->8222/tcp
compose_orthanc_1       Orthanc /etc/orthanc/            Up      4242/tcp, 0.0.0.0:8042->8042/tcp
compose_postgres_1      sh -c $(ls -d /usr/pgsql*/ ...   Up      0.0.0.0:5432->5432/tcp
compose_zookeeper_1     sh -c bin/zkServer.sh star ...   Up      0.0.0.0:2181->2181/tcp
===============================================
Dixons-MBP compose$ docker-compose exec postgres psql -c "SHOW SERVER_ENCODING"
 server_encoding
-----------------
 UTF8
(1 row)
```