### PR TITLE
Image Updates

### DIFF
--- a/base-alpine/Dockerfile
+++ b/base-alpine/Dockerfile
@@ -4,7 +4,7 @@
 # Environment variables:
 # - APP_ROOT: The root application directory.
 
-FROM alpine:3.12.1
+FROM alpine:3.14.2
 LABEL maintainer="Linux for Health"
 LABEL com.linuxforhealth.component="base-image"
 LABEL name="base-image"

--- a/base-alpine/README.md
+++ b/base-alpine/README.md
@@ -1,13 +1,15 @@
-# Linux for Health Base Image
+# LinuxForHealth Base Image
+The LinuxForHealth Base Image is utilized by LinuxForHealth applications and supporting services.
 
-The Linux for Health Base Image provides a minimal Alpine OS with an application directory and non-privileged user.
+Provided settings include:
+- A root application directory, defined in /opt/lfh
+- A non privileged user, user id 1001used to run the containerized application or service
 
 ## Build Command
-
 ```
 docker buildx build \
               --pull \
               --push \
               --platform linux/amd64,linux/s390x,linux/arm64 \
-              -t docker.io/linuxforhealth/base-alpine:<image version> .
+              -t docker.io/linuxforhealth/base:<base version>-alpine-<alpine version> .
 ```

--- a/kafka-alpine/Dockerfile
+++ b/kafka-alpine/Dockerfile
@@ -1,8 +1,8 @@
-# Linux for Health Kafka "stand-alone" image.
+# LinuxForHealth Kafka image.
 #
-# This image provides a "stand-alone" Kafka implementation for non-production use.
-# Zookeeper is not bundled with this image. Zookeeper connection information is provided
-# via the KAFKA_ZOOKEEPER_CONNECT environment variable.
+# The LinuxForHealth Kafka Image provides data storage for LinuxForHealth connect nodes.
+# 
+# Zookeeper (not bundled) is configured using the KAFKA_ZOOKEEPER_CONNECT environment variable.
 #
 # Build arguments:
 # - KAFKA_RELEASE_URL: The URL for the target Kafka release
@@ -16,9 +16,9 @@
 # - KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: Specifies the protocol used for each listener (maps to listener.security.protocol.map)
 # - KAFKA_INTER_BROKER_LISTENER_NAME:  The listener used for internal connections (inter.broker.listener.name)
 
-FROM docker.io/linuxforhealth/base-alpine:1.0.0  AS builder
+FROM docker.io/linuxforhealth/base:1.0.0-alpine-3.14.2  AS builder
 
-ARG KAFKA_RELEASE_URL=https://apache.osuosl.org/kafka/2.5.0/kafka_2.12-2.5.0.tgz
+ARG KAFKA_RELEASE_URL=https://apache.osuosl.org/kafka/3.0.0/kafka_2.13-3.0.0.tgz
 
 RUN apk add -U wget tar gzip && \
     rm -rf /var/lib/apt/lists/*
@@ -29,14 +29,14 @@ RUN wget ${KAFKA_RELEASE_URL} -O /tmp/kafka.tgz && \
     tar -xzf kafka.tgz -C kafka --strip-components 1
 COPY lfh-kafka-start.sh /tmp/kafka/bin
 
-FROM docker.io/linuxforhealth/openjdk-alpine:11
+FROM docker.io/linuxforhealth/openjdk:11-alpine-3.14.2
 
-LABEL maintainer="Linux for Health"
-LABEL com.linuxforhealth.component="kafka-standalone"
-LABEL name="kafka-standalone"
+LABEL maintainer="LinuxForHealth"
+LABEL com.linuxforhealth.component="kafka"
+LABEL name="LinuxForHealth Kafka Alpine"
 LABEL com.linuxforhealth.license_terms="https://www.apache.org/licenses/LICENSE-2.0"
-LABEL summary="Kafka Standalone Deployment for Linux For Health"
-LABEL description="Provides a standalone deployment for non-production use"
+LABEL summary="LinuxForHealth Kafka Alpine Image"
+LABEL description="Provides data storage for LinuxForHealth connect nodes"
 
 ENV KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
 ENV KAFKA_LISTENERS=PLAINTEXT://:9092
@@ -53,7 +53,7 @@ RUN chmod u+x ${APP_ROOT}/kafka/bin/lfh-kafka-start.sh && \
 
 USER lfh
 
-# kafka brokers 1
+# kafka brokers
 EXPOSE 9092 9094
 
 WORKDIR ${APP_ROOT}

--- a/kafka-alpine/README.md
+++ b/kafka-alpine/README.md
@@ -1,6 +1,6 @@
-# Linux for Health Kafka Standalone Image
+# LinuxForHealth Kafka Image
 
-The Linux for Health Kafka Standalone Image is intended for non-production use.
+The LinuxForHealth Kafka Image provides data storage for LinuxForHealth connect nodes. 
 
 ## Build Command
 
@@ -9,7 +9,7 @@ docker buildx build \
               --pull \
               --push \
               --platform linux/amd64,linux/s390x,linux/arm64 \
-              -t docker.io/linuxforhealth/kafka-alpine:<image version> .
+              -t docker.io/linuxforhealth/kafka:<kafka version>-alpine:<alpine version> .
 ```
 
 ## Environment Variables

--- a/openjdk-alpine/Dockerfile
+++ b/openjdk-alpine/Dockerfile
@@ -1,4 +1,4 @@
-# Linux for Health OpenJDK Image
+# LinuxForHealth OpenJDK Image
 # Builds an image for use  by OpenJDK applications
 #
 # Build arguments:
@@ -9,7 +9,7 @@
 # - JAVA_HOME: The Java installation directory
 # - JAVA_OPTIONS: Java command line options used to configure the JVM. Defaults to include the UseContainerSupport options
 
-FROM docker.io/linuxforhealth/base-alpine:1.0.0
+FROM docker.io/linuxforhealth/base:1.0.0-alpine-3.14.2
 
 LABEL maintainer="Linux for Health"
 LABEL com.linuxforhealth.component="jdk-image"

--- a/openjdk-alpine/README.md
+++ b/openjdk-alpine/README.md
@@ -1,6 +1,6 @@
-# Linux for Health OpenJDK Image
+# LinuxForHealth OpenJDK Image
 
-The Linux for Health OpenJDK Image supports java-based applications and services.
+The LinuxForHealth OpenJDK Image supports java-based applications and services.
 
 ## Build Command
 
@@ -15,7 +15,7 @@ docker buildx build \
               --push \
               --platform linux/amd64,linux/s390x,linux/arm64 \
               --build-arg JDK_PACKAGE_NAME=openjdk8-jre \
-              -t docker.io/linuxforhealth/openjdk-alpine:<image version> .
+              -t docker.io/linuxforhealth/openjdk:<jdk version>-alpine-<alpine version> .
 ```
 
 To build for Java 11:
@@ -24,5 +24,5 @@ docker buildx build \
               --pull \
               --push \
               --platform linux/amd64,linux/s390x,linux/arm64 \
-              -t docker.io/linuxforhealth/openjdk-alpine:<image version> .
+              -t docker.io/linuxforhealth/openjdk:<jdk version>-alpine-<alpine version> .
 ```

--- a/zookeeper-alpine/Dockerfile
+++ b/zookeeper-alpine/Dockerfile
@@ -1,6 +1,6 @@
-# Linux for Health ZooKeeper "stand-alone" image.
+# LinuxForHealth ZooKeeper Alpine image.
 #
-# This image provides a "stand-alone" ZooKeeper implementation for non-production use.
+# The LinuxForHealth Zookeeper Alpine image provides LinuxForHealth Kafka with metadata support.
 #
 # Build arguments:
 # - ZOOKEEPER_RELEASE_URL: The URL for the target ZooKeeper release
@@ -9,9 +9,9 @@
 # - APP_ROOT: The root application directory. Set in base image.
 # - JAVA_HOME: The Java installation directory. Set in base image.
 
-FROM docker.io/linuxforhealth/base-alpine:1.0.0  AS builder
+FROM docker.io/linuxforhealth/base:1.0.0-alpine-3.14.2  AS builder
 
-ARG ZOOKEEPER_RELEASE_URL=http://mirrors.ibiblio.org/apache/zookeeper/zookeeper-3.6.2/apache-zookeeper-3.6.2-bin.tar.gz
+ARG ZOOKEEPER_RELEASE_URL=http://mirrors.ibiblio.org/apache/zookeeper/zookeeper-3.6.3/apache-zookeeper-3.6.3-bin.tar.gz
 
 RUN apk add -U wget tar gzip && \
     rm -rf /var/lib/apt/lists/*
@@ -24,14 +24,14 @@ RUN wget ${ZOOKEEPER_RELEASE_URL} -O /tmp/zookeeper.tgz && \
     tar -xzf zookeeper.tgz -C zookeeper --strip-components 1
 COPY zoo.cfg /tmp/zookeeper/conf/
 
-FROM docker.io/linuxforhealth/openjdk-alpine:11
+FROM docker.io/linuxforhealth/openjdk:11-alpine-3.14.2
 
-LABEL maintainer="Linux for Health"
-LABEL com.linuxforhealth.component="zookeeper-standalone"
-LABEL name="zookeeper-standalone"
+LABEL maintainer="LinuxForHealth"
+LABEL com.linuxforhealth.component="zookeeper"
+LABEL name="LinuxForHealth Zookeeper Alpine"
 LABEL com.linuxforhealth.license_terms="https://www.apache.org/licenses/LICENSE-2.0"
-LABEL summary="ZooKeeper Standalone Deployment for Linux For Health"
-LABEL description="Provides a standalone ZooKeeper deployment for non-production use"
+LABEL summary="LinuxForHealth Zookeeper Alpine Image"
+LABEL description="Supports the LinuxForHealth Kafka Alpine image"
 
 RUN mkdir -p ${APP_ROOT}/zookeeper
 COPY --from=builder tmp/zookeeper ${APP_ROOT}/zookeeper

--- a/zookeeper-alpine/README
+++ b/zookeeper-alpine/README
@@ -1,6 +1,6 @@
-# Linux for Health Zookeeper Standalone Image
+# LinuxForHealth Zookeeper Standalone Image
 
-The Linux for Health Zookeeper Standalone Image is intended for non-production use.
+The LinuxForHealth Zookeeper image provides LinuxForHealth Kafka with metadata support.
 
 ## Build Command
 ```
@@ -8,5 +8,5 @@ docker buildx build \
               --pull \
               --push \
               --platform linux/amd64,linux/s390x,linux/arm64 \
-              -t docker.io/linuxforhealth/zookeeper-alpine:<image version> .
+              -t docker.io/linuxforhealth/zookeeper:<zookeeper version>-alpine-<alpine version> .
 ```


### PR DESCRIPTION
LinuxForHealth provides UBI and Alpine based images for supporting applications and services. 

Active development has focused on the Alpine based images, leaving the UBI images unmaintained.   This PR initiates the process of consolidating image development on Alpine. A follow-up PR will remove UBI image directories and “rename” the alpine image directories (kaka-alpine -> kafka). We will also update the LinuxForHealth DockerHub site accordingly.  

PR updates include:
 * Update images to use a new versioning standard, <image name>:<image version>-alpine-<alpine version> 
 * build instructions in README files reflect the versioning standard in build instructions 
 * Dockerfile FROM statements specify the new image versions  
 
 This versioning standard aligns LinuxForHealth with “versioning best practices” where the image tag contains the application/service and “os” version. This standard is capable of supporting new “os” versions (ubuntu, debian, reintroduce UBI) as needed under a central application/service name such as “kafka” rather than “kafka-ubuntu”, “kafka-alpine”, etc 
 
 Base Image  - https://hub.docker.com/repository/docker/linuxforhealth/base

 OpenJDK Image -  https://hub.docker.com/repository/docker/linuxforhealth/openjdk

 Kafka Image- https://hub.docker.com/repository/docker/linuxforhealth/kafka

Zookeeper Image - https://hub.docker.com/repository/docker/linuxforhealth/zookeeper

Signed-off-by: Dixon Whitmire <dixonwh@gmail.com>